### PR TITLE
Bugfix in reading MAT_v5 files

### DIFF
--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -144,7 +144,9 @@ function read_struct(f::IOStream, swap_bytes::Bool, dimensions::Vector{Int32}, i
         field_name_strings[i] = ascii(index == 0 ? sname : sname[1:index-1])
     end
 
-    data = Dict{ASCIIString, Any}(n_fields+1)
+    #data = Dict{ASCIIString, Any}(n_fields+1)
+    data = Dict{ASCIIString, Any}()
+    sizehint(data, n_fields+1)
     if is_object
         data["class"] = class
     end


### PR DESCRIPTION
I just discovered Julia this afternoon and was excited to see this library for reading Matlab files.  But, when I installed it and tried reading a simple MAT-file, I got this error:

```
ERROR: no method Dict(Int64,)
 in read_struct at /home/geoff/.julia/MAT/src/MAT_v5.jl:147
 in read_matrix at /home/geoff/.julia/MAT/src/MAT_v5.jl:240
 in read_matrix at /home/geoff/.julia/MAT/src/MAT_v5.jl:215
 in read at /home/geoff/.julia/MAT/src/MAT_v5.jl:292
 in matread at /home/geoff/.julia/MAT/src/MAT.jl:74
```

I'm guessing maybe the syntax for the Dict constructor has recently changed? Anyway, it seems like changing line 147 to:

```
data = Dict{ASCIIString, Any}()
sizehint(data, n_fields+1)
```

seems to work.
