### PR TITLE
Fix missing separator in `matwrite` usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To write a Dict to a MAT file, using its keys as variable names:
 
 ```julia
 matwrite("matfile.mat", {
-	"myvar1" => 0
+	"myvar1" => 0,
 	"myvar2" => 1
 })
 ```


### PR DESCRIPTION
Should there be a `,` between `"myvar2" => 0` and `"myvar2" => 1`?
