### PR TITLE
Support for [] getindex/setindex! syntax. Fix #30

### DIFF
--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -28,7 +28,7 @@
 
 module MAT_HDF5
 using HDF5
-import Base: read, write, close
+import Base: read, write, close, getindex, setindex!
 import HDF5: names, exists, HDF5ReferenceObj, HDF5BitsKind
 
 type MatlabHDF5File <: HDF5.DataFile
@@ -241,6 +241,9 @@ function read(f::MatlabHDF5File, name::ASCIIString)
     end
     val
 end
+
+getindex(f::MatlabHDF5File, name::ASCIIString) = read(f, name)
+getindex(f::MatlabHDF5File, name::Symbol) = read(f, string(name))
 
 names(f::MatlabHDF5File) = filter!(x->x != "#refs#", names(f.plain))
 exists(p::MatlabHDF5File, path::ASCIIString) = exists(p.plain, path)
@@ -479,6 +482,9 @@ function write(parent::MatlabHDF5File, name::ByteString, thing)
     check_valid_varname(name)
     m_write(parent, parent.plain, name, thing)
 end
+
+setindex!(parent::MatlabHDF5File, thing, name::ByteString) = write(parent, name, thing)
+setindex!(parent::MatlabHDF5File, thing, name::Symbol) = write(parent, string(name), thing)
 
 ## Type conversion operations ##
 

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -27,7 +27,7 @@
 
 module MAT_v5
 using Zlib, HDF5
-import Base: read, write, close
+import Base: read, write, close, getindex, setindex!
 import HDF5: names, exists
 
 type Matlabv5File <: HDF5.DataFile
@@ -439,10 +439,18 @@ function read(matfile::Matlabv5File, varname::ASCIIString)
     data
 end
 
+# []-accessor syntax.
+getindex(matfile::Matlabv5File, varname::ASCIIString) = read(matfile, varname)
+getindex(matfile::Matlabv5File, varname::Symbol) = read(matfile, string(varname))
+
 # Complain about writing to a MAT file
-function write(parent::Matlabv5File, name::ByteString, s)
+function write(parent::Matlabv5File, name::ASCIIString, s)
     error("Writing to a MATLAB v5 file is not currently supported. Create a new file instead.")
 end
+
+# For completeness' sake
+setindex!(parent::Matlabv5File, s, name::ASCIIString) = write(parent, name, s)
+setindex!(parent::Matlabv5File, s, name::Symbol) = write(parent, string(name), s)
 
 # Close MAT file
 close(matfile::Matlabv5File) = close(matfile.ios)


### PR DESCRIPTION
A pretty simple change, but I still need comments:
1. Why do the `write` methods get a `ByteString` for the variable name while the `read` methods get an `ASCIIString`?
2. Do you want the `Symbol` syntax `file[:varname]`, or is that too many ways to do the same thing?
