### PR TITLE
Fixed Compat deprecation warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
     - linux
     - osx
 julia:
-    - 0.4
     - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 HDF5
 BufferedStreams 0.2.0
 Libz

--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -150,7 +150,7 @@ function matwrite{S, T}(filename::AbstractString, dict::Associative{S, T})
         for (k, v) in dict
             local kstring
             try
-                kstring = ascii(convert(Compat.ASCIIString, k))
+                kstring = ascii(convert(String, k))
             catch x
                 error("matwrite requires a Dict with ASCII keys")
             end

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -232,7 +232,7 @@ function m_read(g::HDF5Group)
     else
         fn = names(g)
     end
-    s = Dict{Compat.ASCIIString, Any}()
+    s = Dict{String, Any}()
     for i = 1:length(fn)
         dset = g[fn[i]]
         try
@@ -251,7 +251,7 @@ Read a variable from an opened Matlab file and return its value.
 
 See `matopen` and `matread`.
 """
-function read(f::MatlabHDF5File, name::Compat.ASCIIString)
+function read(f::MatlabHDF5File, name::String)
     local val
     obj = f.plain[name]
     try
@@ -278,7 +278,7 @@ Return true if a variable is present in an opened Matlab file.
 
 See `matopen`.
 """
-exists(p::MatlabHDF5File, path::Compat.ASCIIString) = exists(p.plain, path)
+exists(p::MatlabHDF5File, path::String) = exists(p.plain, path)
 
 ### Writing
 
@@ -482,20 +482,20 @@ end
 
 # Check that keys are valid for a struct, and convert them to an array of ASCIIStrings
 function check_struct_keys(k::Vector)
-    asckeys = Vector{Compat.ASCIIString}(length(k))
+    asckeys = Vector{String}(length(k))
     for i = 1:length(k)
         key = k[i]
         if !isa(key, AbstractString)
             error("Only Dicts with string keys may be saved as MATLAB structs")
         end
         check_valid_varname(key)
-        asckeys[i] = convert(Compat.ASCIIString, key)
+        asckeys[i] = convert(String, key)
     end
     asckeys
 end
 
 # Write a struct from arrays of keys and values
-function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, k::Vector{Compat.ASCIIString}, v::Vector)
+function m_write(mfile::MatlabHDF5File, parent::HDF5Parent, name::String, k::Vector{String}, v::Vector)
     g = g_create(parent, name)
     a_write(g, name_type_attr_matlab, "struct")
     for i = 1:length(k)
@@ -590,9 +590,9 @@ function read(obj::HDF5Object, ::Type{MatlabString})
         data = reshape(data, sz[2:end])
     end
     if ndims(data) == 1
-        return convert(Compat.UTF8String, convert(Vector{Char}, data))
+        return convert(String, convert(Vector{Char}, data))
     elseif ndims(data) == 2
-        return datap = Compat.String[rstrip(convert(Compat.UTF8String, convert(Vector{Char}, vec(data[i, :])))) for i = 1:size(data, 1)]
+        return datap = Compat.String[rstrip(convert(String, convert(Vector{Char}, vec(data[i, :])))) for i = 1:size(data, 1)]
     else
         return data
     end

--- a/test/read.jl
+++ b/test/read.jl
@@ -103,12 +103,12 @@ for format in ["v6", "v7", "v7.3"]
     check("cell.mat", result)
 
     result = Dict(
-        "s" => Dict{Compat.ASCIIString,Any}(
+        "s" => Dict{String,Any}(
             "a" => 1.0,
             "b" => [1.0 2.0],
             "c" => [1.0 2.0 3.0]
         ),
-        "s2" => Dict{Compat.ASCIIString,Any}("a" => Any[1.0 2.0])
+        "s2" => Dict{String,Any}("a" => Any[1.0 2.0])
     )
     check("struct.mat", result)
 


### PR DESCRIPTION
Closes #72 

- Converted ASCIIString/UTF8String to String.
- Bumped julia minimum version number as Compat has dropped support for 0.4