### PR TITLE
Changes to improve v1.0 handling

### DIFF
--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -27,6 +27,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 module MAT
 
 using HDF5, Compat
+using Compat.SparseArrays
 
 include("MAT_HDF5.jl")
 include("MAT_v5.jl")

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -130,19 +130,9 @@ function read_complex(dtype::HDF5Datatype, dset::HDF5Dataset, ::Type{Array{T}}) 
     end
     memtype = build_datatype_complex(T)
     sz = size(dset)
-    dbuf = Array{T}(2, sz...)
-    st = sizeof(T)
-    buf = reinterpret(UInt8, dbuf, (2 * st, sz...))
-    HDF5.h5d_read(dset.id, memtype.id, HDF5.H5S_ALL, HDF5.H5S_ALL, HDF5.H5P_DEFAULT, buf)
-
-    if T == Float32
-        d = reinterpret(ComplexF32, dbuf, sz)
-    elseif T == Float64
-        d = reinterpret(ComplexF64, dbuf, sz)
-    else
-        d = slicedim(dbuf, 1, 1) + im * slicedim(dbuf, 1, 2)
-    end
-    length(d) == 1 ? d[1] : d
+    dbuf = Array{Complex{T}}(undef, sz...)
+    HDF5.h5d_read(dset.id, memtype.id, HDF5.H5S_ALL, HDF5.H5S_ALL, HDF5.H5P_DEFAULT, vec(dbuf))
+    length(dbuf) == 1 ? dbuf[1] : dbuf
 end
 
 function m_read(dset::HDF5Dataset)

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -618,8 +618,13 @@ function read(obj::HDF5Object, ::Type{Bool})
     tf > 0
 end
 function read(obj::HDF5Object, ::Type{Array{Bool}})
-    tf = read(obj, Array{UInt8})
-    reinterpret(Bool, tf)
+    if HDF5.isnull(obj)
+        return Bool[]
+    end
+    # Use the low-level HDF5 API to put the data directly into a Bool array
+    tf = Array{Bool}(undef, size(obj))
+    HDF5.h5d_read(obj.id, HDF5.hdf5_type_id(UInt8), tf, obj.xfer)
+    tf
 end
 
 ## Utilities for handling complex numbers

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -596,9 +596,9 @@ function read(obj::HDF5Object, ::Type{MatlabString})
         data = reshape(data, sz[2:end])
     end
     if ndims(data) == 1
-        return convert(String, convert(Vector{Char}, data))
+        return String(convert(Vector{Char}, data))
     elseif ndims(data) == 2
-        return datap = String[rstrip(convert(String, convert(Vector{Char}, vec(data[i, :])))) for i = 1:size(data, 1)]
+        return datap = String[rstrip(String(convert(Vector{Char}, vec(data[i, :])))) for i = 1:size(data, 1)]
     else
         return data
     end

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -137,7 +137,7 @@ end
 function read_data(f::IO, swap_bytes::Bool, ::Type{T}, dimensions::Vector{Int32}) where {T}
     (dtype, nbytes, hbytes) = read_header(f, swap_bytes)
     read_type = READ_TYPES[dtype]
-    if (read_type == UInt8) && (T === Bool)
+    if (read_type === UInt8) && (T === Bool)
         read_type = Bool
     end
 

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -27,6 +27,7 @@
 
 module MAT_v5
 using Libz, BufferedStreams, HDF5, Compat
+using Compat.SparseArrays
 import Base: read, write, close
 import HDF5: names, exists
 

--- a/src/MAT_v5.jl
+++ b/src/MAT_v5.jl
@@ -137,6 +137,9 @@ end
 function read_data(f::IO, swap_bytes::Bool, ::Type{T}, dimensions::Vector{Int32}) where {T}
     (dtype, nbytes, hbytes) = read_header(f, swap_bytes)
     read_type = READ_TYPES[dtype]
+    if (read_type == UInt8) && (T === Bool)
+        read_type = Bool
+    end
 
     read_array = any(dimensions .!= 1)
     if sizeof(read_type)*prod(dimensions) != nbytes
@@ -329,12 +332,14 @@ function read_matrix(f::IO, swap_bytes::Bool)
     elseif class == mxCHAR_CLASS && length(dimensions) <= 2
         data = read_string(f, swap_bytes, dimensions)
     else
-        convert_type = CONVERT_TYPES[class]
-        data = read_data(f, swap_bytes, convert_type, dimensions)
-        if (flags[1] & (1 << 11)) != 0 # complex
-            data = complex_array(data, read_data(f, swap_bytes, convert_type, dimensions))
-        elseif (flags[1] & (1 << 9)) != 0 # logical
-            data = reinterpret(Bool, round_uint8(data))
+        if (flags[1] & (1 << 9)) != 0 # logical
+            data = read_data(f, swap_bytes, Bool, dimensions)
+        else
+            convert_type = CONVERT_TYPES[class]
+            data = read_data(f, swap_bytes, convert_type, dimensions)
+            if (flags[1] & (1 << 11)) != 0 # complex
+                data = complex_array(data, read_data(f, swap_bytes, convert_type, dimensions))
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using Compat
+using Compat.SparseArrays
+using Compat.LinearAlgebra
 
 include("read.jl")
 include("write.jl")


### PR DESCRIPTION
This PR improves compatibility with v1.0 in a similar vein to #86 but uses the low-level HDF5 interface to avoid having to use reinterpret. It doesn't fix all the compatibility problems (I haven't had time) but it shouldn't break v0.6 compatibility either (waiting on CI to confirm).