### PR TITLE
Moved from Libz to CodecZlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ julia:
     - 0.7
     - 1.0
     - 1.1
+	- 1.3
     - nightly
 addons:
 #  apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ julia:
     - 0.7
     - 1.0
     - 1.1
-	- 1.3
+    - 1.3
     - nightly
 addons:
 #  apt:

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "MAT"
 uuid = "23992714-dd62-5051-b70f-ba57cb901cac"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-Libz = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 
 [compat]
 BufferedStreams = "≥ 0.2.0"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 BufferedStreams = "≥ 0.2.0"
 HDF5 = "≥ 0.11.0"
 julia = "0.7, 1"
-CodecZlib = "≥ 0.6.0" 
+CodecZlib = "≥ 0.5.0" 
 
 [extras]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MAT"
 uuid = "23992714-dd62-5051-b70f-ba57cb901cac"
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
@@ -12,6 +12,7 @@ CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 BufferedStreams = "≥ 0.2.0"
 HDF5 = "≥ 0.11.0"
 julia = "0.7, 1"
+CodecZlib = "≥ 0.6.0" 
 
 [extras]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Julia 1.3.0 breaks Libz on Windows; rather than fix Libz, why not move to CodecZlib?
Added laserscout's pull request laserscout@c5e972b
to the latest version, moving to CodecLibz. This is recommended by the Libz library:
https://github.com/BioJulia/Libz.jl

> NOTE: If you are starting a new project on Julia 0.6 or later, it is recommended to use the CodecZlib.jl package instead.

Tested on Windows 10, test cases run and my project works again!