### PR TITLE
Update .travis.yml to check for julia 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ julia:
     - 0.7
     - 1.0
     - 1.1
+    - 1.2
     - 1.3
     - nightly
 addons:


### PR DESCRIPTION
Useful for people using JuliaPro distribution, which currently comes bundled with Julia 1.2