### PR TITLE
Fix incorrect wrapping of a Datatype

### DIFF
--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -607,10 +607,10 @@ end
 
 ## Utilities for handling complex numbers
 function build_datatype_complex(T::Type)
-    memtype_id = create_datatype(HDF5.H5T_COMPOUND, 2*sizeof(T))
-    HDF5.h5t_insert(memtype_id, "real", 0, HDF5.hdf5_type_id(T))
-    HDF5.h5t_insert(memtype_id, "imag", sizeof(T), HDF5.hdf5_type_id(T))
-    HDF5.Datatype(memtype_id)
+    memtype = create_datatype(HDF5.H5T_COMPOUND, 2*sizeof(T))
+    HDF5.h5t_insert(memtype, "real", 0, HDF5.hdf5_type_id(T))
+    HDF5.h5t_insert(memtype, "imag", sizeof(T), HDF5.hdf5_type_id(T))
+    return memtype
 end
 
 function check_datatype_complex(dtype::HDF5.Datatype)


### PR DESCRIPTION
This was noticed in the CI of #145.

`create_datatype` already returns an HDF5.Datatype object, so by
wrapping again, the finalizer on the original object was allowed to
run too early.