### PR TITLE
WIP: read (some) v4 format files

### DIFF
--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -28,6 +28,7 @@ using HDF5, SparseArrays
 
 include("MAT_HDF5.jl")
 include("MAT_v5.jl")
+include("MAT_v4.jl")
 
 using .MAT_HDF5, .MAT_v5
 
@@ -54,8 +55,10 @@ function matopen(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Boo
     magic = read!(rawfid, Vector{UInt8}(undef, 4))
     for i = 1:length(magic)
         if magic[i] == 0
-            close(rawfid)
-            error("\"$filename\" is not a MAT file, or is an unsupported (v4) MAT file")
+            if wr || cr || tr || ff
+                error("creating or appending to MATLAB v4 files is not supported")
+            end
+            return MAT_v4.matopen(rawfid)
         end
     end
 

--- a/src/MAT_v4.jl
+++ b/src/MAT_v4.jl
@@ -54,4 +54,6 @@ function read(mat::Matlabv4File)
     return results
 end
 
+close(mat::Matlabv4File) = close(mat.ios)
+
 end # module

--- a/src/MAT_v4.jl
+++ b/src/MAT_v4.jl
@@ -1,0 +1,57 @@
+module MAT_v4
+
+import Base: read, write, close
+
+mutable struct Matlabv4File
+    ios::IOStream
+    varnames::Dict{String, Int64}
+
+    Matlabv4File(ios) = new(ios)
+end
+
+const V4_ELTYPE = [Float64, Float32, Int32, Int16, UInt16, UInt8]
+
+matopen(ios::IOStream) = Matlabv4File(ios)
+
+function unpack_header_type(type::Int32)
+    T, P, O, M = digits(type; pad=4)
+    iszero(O) || error("file is not a v4 MAT file (magic digit not 0)")
+    iszero(M) || error("only little endian v4 MAT currently supported")
+    iszero(T) || error("only full numeric matrices supported for v4 MAT files")
+
+    P in 0:5 || error("invalid eltype digit in v4 MAT file: $P")
+    eltype = V4_ELTYPE[P+1]
+
+    return eltype
+end
+
+function read_one_mat!(mat::Matlabv4File)
+    type, mrows, ncols, imagf, namlen = read!(mat.ios, Vector{Int32}(undef, 5))
+    eltype = unpack_header_type(type)
+
+    iszero(imagf) || error("no imaginary matrix support")
+
+    name = String(read!(mat.ios, Vector{UInt8}(undef, namlen-1)))
+
+    # one null byte before start of matrix data
+    Base.read(mat.ios, UInt8)
+
+    @show mrows, ncols
+    value = read!(mat.ios, Matrix{eltype}(undef, mrows, ncols))
+
+    return name => value
+end
+
+function read(mat::Matlabv4File)
+    seekstart(mat.ios)
+
+    results = Dict{String,Any}()
+    while !eof(mat.ios)
+        name, value = read_one_mat!(mat)
+        results[name] = value
+    end
+    
+    return results
+end
+
+end # module


### PR DESCRIPTION
This is based on the spec I found here: https://www.eiscat.se/wp-content/uploads/2016/03/Version-4-MAT-File-Format.pdf  It doesn't handle everything but maybe it's better than nothing!

Unfortunately I lack a sufficiently diverse collection of .mat files to test this against but it works for the one type of file I do have a lot of (a single `Int16` matrix per .mat file).