### PR TITLE
Remove invalid import of `exists` from HDF5

### DIFF
--- a/src/MAT.jl
+++ b/src/MAT.jl
@@ -165,7 +165,6 @@ end
 ### v0.10.0 deprecations
 ###
 
-import HDF5: exists
 export exists
 @noinline function exists(matfile::Union{MAT_v5.Matlabv5File,MAT_HDF5.MatlabHDF5File}, varname::String)
     Base.depwarn("`exists(matfile, varname)` is deprecated, use `haskey(matfile, varname)` instead.", :exists)


### PR DESCRIPTION
The import of `HDF5.exists` fails and results in a warning.

```julia
WARNING: could not import HDF5.exists into MAT
```

- `HDF5` dropped the function `exists` pre-v0.16 (https://github.com/JuliaIO/HDF5.jl/pull/694).
- The only supported version of `HDF5` is v0.16 since #172.

Hence the import will never work with the latest version of `MAT` and can be safely removed without breaking anything.