### PR TITLE
Strip null characters from variable name in `getvarnames`

### DIFF
--- a/src/MAT_v4.jl
+++ b/src/MAT_v4.jl
@@ -187,7 +187,7 @@ function getvarnames(matfile::Matlabv4File)
             M, O, P, T, mrows, ncols, imagf, namlen = read_header(matfile.ios, matfile.swap_bytes)
             f = matfile.ios
             
-            name = String(read_bswap(f, M==mBIG_ENDIAN, Vector{UInt8}(undef, namlen))[1:end-1])
+            name = strip(String(read_bswap(f, M==mBIG_ENDIAN, Vector{UInt8}(undef, namlen))), '\0')
             varnames[name] = offset
             imag_offset = 0
             skip(f, mrows*ncols*sizeof(pTYPE[P]))


### PR DESCRIPTION
This udpates `getvarnames` to match the functionality of `read_matrix` using `strip` to deal with the possibility of terminal (or beginning) null characters.

Note: `getvarnames` is only used when 1) checking if a `Matlabv4File` has a specific key, 2) getting the keys of such a file OR 3) `read`ing a specific variable from such a file.