### PR TITLE
support setindex! for MatlabStructArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MAT"
 uuid = "23992714-dd62-5051-b70f-ba57cb901cac"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/src/MAT_types.jl
+++ b/src/MAT_types.jl
@@ -185,6 +185,19 @@ function Base.getindex(m::MatlabStructArray, s::AbstractString)
     return getindex(m.values, idx)
 end
 
+function Base.setindex!(m::MatlabStructArray{N1}, input::AbstractArray{T,N2}, s::AbstractString) where {N1,N2,T}
+    error("size of input is not equal to MatlabStructArray column size")
+end
+
+function Base.setindex!(m::MatlabStructArray{N}, input::AbstractArray{T,N}, s::AbstractString) where {N,T}
+    idx = find_index(m, s)
+    v = Array{Any,N}(input)
+    if size(v) != size(m.values[idx])
+        error("size of input is not equal to MatlabStructArray column size")
+    end
+    return setindex!(m.values, v, idx)
+end
+
 function Base.get(m::MatlabStructArray, s::AbstractString, default)
     idx = findfirst(isequal(s), m.names)
     if isnothing(idx)

--- a/test/types.jl
+++ b/test/types.jl
@@ -42,6 +42,15 @@ using Dates
     @test !haskey(s_arr, "wrong")
     @test get(s_arr, "wrong", nothing) === nothing
 
+    # setindexing
+    msg = "field \"z\" not found in MatlabStructArray"
+    @test_throws ErrorException(msg) s_arr["z"] = [1.0, 2.0]
+    s_arr["x"] = [1.0, 2.0]
+    @test s_arr["x"] == Any[1.0, 2.0]
+    msg = "size of input is not equal to MatlabStructArray column size"
+    @test_throws ErrorException(msg) s_arr["x"] = Any[1.0]
+    @test_throws ErrorException(msg) s_arr["x"] = reshape(Any[1.0,2.0], 1, 2)
+
     # possibility to convert back to dict array via `Array`
     s_arr = MatlabStructArray(d_arr)
     @test Array(s_arr) == d_arr


### PR DESCRIPTION
This was missing 'dict-like' functionality for `MatlabStructArray`

This immediately solves an issue for `MAT.MAT_subsys.update_nested_props!(::MatlabStructArray, ::Subsystem)` which calls the `setindex!` function. 