### PR TITLE
Fix: MAT_subsys.get_dynamic_properties() returns empty dict if dynprop_metadata is empty

### DIFF
--- a/src/MAT_subsys.jl
+++ b/src/MAT_subsys.jl
@@ -301,6 +301,11 @@ function get_saved_properties(
 end
 
 function get_dynamic_properties(subsys::Subsystem, dep_id::UInt32)
+
+    if length(subsys.dynprop_metadata) == 0
+        return Dict{String,Any}()
+    end
+
     offset = 1
     while dep_id > 0
         nprops = subsys.dynprop_metadata[offset]


### PR DESCRIPTION
Newer MATLAB versions seem to omit `dynprop_metadata` altogether if there are no dynamic properties to save. This fix should cover the case when this metadata field is empty.

Fixes #212 