### PR TITLE
avoid HDF5.name when possible

### DIFF
--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -144,8 +144,10 @@ function matopen(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Boo
         fid.subsystem.table_type = table
         fid.subsystem.convert_opaque = convert_opaque
         subsys_group::HDF5.Group = fid.plain[subsys_refs]
-        subsys_data = m_read(subsys_group, fid.subsystem; check_subsystem=true)
+        HDF5.name(subsys_group) == "/#subsystem#" || error("Invalid subsystem group name")
+        subsys_data = m_read(subsys_group, fid.subsystem, "#subsystem#")
         MAT_subsys.load_subsys!(fid.subsystem, subsys_data, endian_indicator)
+        close(subsys_group)
     elseif wr
         MAT_subsys.init_save!(fid.subsystem)
     end
@@ -317,13 +319,12 @@ function read_struct_as_dict(g::HDF5.Group, subsys::Subsystem)
 end
 
 # reading a struct, struct array, or sparse matrix
-function m_read(g::HDF5.Group, subsys::Subsystem; check_subsystem::Bool=false)
-    if check_subsystem && HDF5.name(g) == "/#subsystem#"
-        # note: HDF5.name usage can be slow for larger files, so try to avoid it
-        mattype = "#subsystem#"
-    else
-        mattype = read_attribute(g, name_type_attr_matlab)
-    end
+function m_read(g::HDF5.Group, subsys::Subsystem)
+    mattype = read_attribute(g, name_type_attr_matlab)
+    return m_read(g, subsys, mattype)
+end
+
+function m_read(g::HDF5.Group, subsys::Subsystem, mattype::String)
     is_object = false
     if mattype != "struct"
         attr = attributes(g)

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -317,7 +317,8 @@ end
 
 # reading a struct, struct array, or sparse matrix
 function m_read(g::HDF5.Group, subsys::Subsystem)
-    if HDF5.name(g) == "/#subsystem#"
+    if !isempty(subsys) && HDF5.name(g) == "/#subsystem#"
+        # note: HDF5.name usage can be slow for larger files, so try to avoid it
         mattype = "#subsystem#"
     else
         mattype = read_attribute(g, name_type_attr_matlab)

--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -143,7 +143,8 @@ function matopen(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Boo
     if rd && haskey(fid.plain, subsys_refs)
         fid.subsystem.table_type = table
         fid.subsystem.convert_opaque = convert_opaque
-        subsys_data = m_read(fid.plain[subsys_refs], fid.subsystem)
+        subsys_group::HDF5.Group = fid.plain[subsys_refs]
+        subsys_data = m_read(subsys_group, fid.subsystem; check_subsystem=true)
         MAT_subsys.load_subsys!(fid.subsystem, subsys_data, endian_indicator)
     elseif wr
         MAT_subsys.init_save!(fid.subsystem)
@@ -316,8 +317,8 @@ function read_struct_as_dict(g::HDF5.Group, subsys::Subsystem)
 end
 
 # reading a struct, struct array, or sparse matrix
-function m_read(g::HDF5.Group, subsys::Subsystem)
-    if !isempty(subsys) && HDF5.name(g) == "/#subsystem#"
+function m_read(g::HDF5.Group, subsys::Subsystem; check_subsystem::Bool=false)
+    if check_subsystem && HDF5.name(g) == "/#subsystem#"
         # note: HDF5.name usage can be slow for larger files, so try to avoid it
         mattype = "#subsystem#"
     else

--- a/src/MAT_subsys.jl
+++ b/src/MAT_subsys.jl
@@ -101,10 +101,6 @@ mutable struct Subsystem
     end
 end
 
-function Base.isempty(subsys::Subsystem)
-    return subsys.class_id_counter == 0
-end
-
 function swapped_reinterpret(T::Type, A::AbstractArray{UInt8}, swap_bytes::Bool)
     return reinterpret(T, swap_bytes ? reverse(A) : A)
 end

--- a/src/MAT_subsys.jl
+++ b/src/MAT_subsys.jl
@@ -101,6 +101,10 @@ mutable struct Subsystem
     end
 end
 
+function Base.isempty(subsys::Subsystem)
+    return subsys.class_id_counter == 0
+end
+
 function swapped_reinterpret(T::Type, A::AbstractArray{UInt8}, swap_bytes::Bool)
     return reinterpret(T, swap_bytes ? reverse(A) : A)
 end


### PR DESCRIPTION
Addresses: https://github.com/JuliaIO/MAT.jl/issues/237
@foreverallama this may interest you.

I want a more performant HDF5.name variant, but in the meantime I can at least speed up .mat files without subsystem information. 

```julia
using MAT, LinearAlgebra

function powerlaw_fit(x, y)
    lx = log10.(x)
    ly = log10.(y)

    A = hcat(ones(length(lx)), lx)
    c = A \ ly

    logC, α = c
    yfit = 10.0^logC .* x .^ α
    return logC, α, yfit
end

function nested_dict()
    Dict{String, Any}(
        "a" => Dict{String, Any}("b" => 1),
    )
end

sizes = logrange(10,1000,10)
timings = Float64[]
timings2 = Float64[]
file_sizes = Float64[]
filename = "matfile.mat"
for N in sizes
    file = matopen(filename, "w")
    write(file, "arr", [nested_dict() for _ in 1:N])
    t = @elapsed read(file, "arr")
    push!(timings, t)
    file.subsystem.class_id_counter = 1 # force use of HDF5.name
    t2 = @elapsed read(file, "arr")
    push!(timings2, t2)
    close(file)
    push!(file_sizes, filesize(filename))
end

logC1, a1, fit1 = powerlaw_fit(file_sizes, timings)
logC2, a2, fit2 = powerlaw_fit(file_sizes, timings2)

using Makie, GLMakie
fig = Figure(size=(700, 300))
ax = Axis(fig[1, 1], xlabel="Size of file (KB)", ylabel="Time (s)")
scatter!(ax, file_sizes/1e3, timings, color=:black, label="no")
scatter!(ax, file_sizes/1e3, timings2, color=:red, label="yes")
lines!(ax, file_sizes/1e3, fit1, color=:black, linestyle=:dash)
lines!(ax, file_sizes/1e3, fit2, color=:red, linestyle=:dash)
Legend(fig[1,3,], ax, "HDF5.name usage")
ax = Axis(fig[1, 2], xlabel="Size of file (KB)", ylabel="Time (s)", xscale=log10, yscale=log10)
scatter!(ax, file_sizes/1e3, timings, color=:black)
scatter!(ax, file_sizes/1e3, timings2, color=:red)
lines!(ax, file_sizes/1e3, fit1, color=:black, linestyle=:dash)
text!(ax, 0.4*file_sizes[end]/1e3, fit1[end], text="x^$(round(a1, sigdigits=2))", color=:black)
lines!(ax, file_sizes/1e3, fit2, color=:red, linestyle=:dash)
text!(ax, 0.4*file_sizes[end]/1e3, 0.7*fit2[end], text="x^$(round(a2, sigdigits=2))", color=:red)
fig
save("timings.png", fig)
```

<img width="740" height="300" alt="timings" src="https://github.com/user-attachments/assets/5d8792d9-287b-4ccf-ac4f-d93adb4ea87b" />

As you see, `HDF5.name` creates quadratic time scaling with file sizes. With this PR we go back to roughly linear scaling by avoiding `HDF5.name` when possible.
